### PR TITLE
Added cofactors comment to complex hover

### DIFF
--- a/modules/org.pathvisio.core/src/org/pathvisio/core/view/model/ViewActions.java
+++ b/modules/org.pathvisio.core/src/org/pathvisio/core/view/model/ViewActions.java
@@ -869,7 +869,7 @@ public class ViewActions implements VPathwayModelListener, SelectionListener {
 			label = "Group related elements (default)";
 			break;
 		case "Complex":
-			label = "Group proteins forming a protein complex";
+			label = "Group proteins and cofactors forming a protein complex";
 			break;
 		case "Pathway":
 			label = "Group elements of a pathway ";


### PR DESCRIPTION
@Finterly : protein complexes might also need cofactors (small molecules) to specify it's function correctly, so I've added that in the hover over menu.