### PR TITLE
Update basic interactions

### DIFF
--- a/modules/org.pathvisio.gui/src/org/pathvisio/gui/MainPanel.java
+++ b/modules/org.pathvisio.gui/src/org/pathvisio/gui/MainPanel.java
@@ -200,8 +200,8 @@ public class MainPanel extends JPanel implements VPathwayModelListener, Applicat
 		int numItemsPerRow = 10;
 		objectsPane.addButtons(actions.newMolecularDatanodeActions, "Molecular DataNodes", numItemsPerRow);
 		objectsPane.addButtons(actions.newConceptDatanodeActions, "Concept DataNodes", numItemsPerRow);
-		objectsPane.addButtons(actions.newBasicInteractionActions, "Basic Interactions", numItemsPerRow);
-		objectsPane.addButtons(actions.newInteractionActions, "Interactions (Recommended)", numItemsPerRow);
+		objectsPane.addButtons(actions.newInteractionActions, "Semantic Interactions (Recommended)", numItemsPerRow);
+		objectsPane.addButtons(actions.newBasicInteractionActions, "Additional Interactions (Basic)", numItemsPerRow);
 		// objectsPane.addButtons(actions.newRLInteractionActions, "Receptor/ligand",
 		// numItemsPerRow);
 		// objectsPane.addButtons(actions.newAnnotationActions, "Annotations",
@@ -357,8 +357,8 @@ public class MainPanel extends JPanel implements VPathwayModelListener, Applicat
 		// define the drop-down menu for interactions
 		GraphicsChoiceButton lineButton = new GraphicsChoiceButton();
 		lineButton.setToolTipText("Select an interaction to draw");
-		lineButton.addButtons("Basic Interactions", actions.newBasicInteractionActions);
-		lineButton.addButtons("Interactions (Recommended)", actions.newInteractionActions);
+		lineButton.addButtons("Semantic Interactions (Recommended)", actions.newInteractionActions);
+		lineButton.addButtons("Additional Interactions (Basic)", actions.newBasicInteractionActions);
 		addToToolbar(lineButton, TB_GROUP_SHOW_IF_EDITMODE);
 		tb.addSeparator(new Dimension(2, 0));
 


### PR DESCRIPTION
Moved basic (not semantic) interactions below the recommended set, renamed the later to 'semantic interactions'

@Finterly @mkutmon : I think the interaction panel will make more sense like this; people read from top to bottom so the recommended stuff should come first.